### PR TITLE
Fix an issue with crash on stage2 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ sysup allows for the possibility of offline updates via an image file containing
    
 ### Additional Update Options
 These arguments are add-ons for the "-update" argument and are typically not needed for standard use
+- **-disablebootstrap**
+   - Skip the update of SysUp port. This is used for running locally built SysUp and testing.
 - **-bename NAME**
    - Use "NAME" for the new boot environment that will be created.
    - A boot environment with "NAME" must *not* already exist, otherwise sysup will return an error.

--- a/client.go
+++ b/client.go
@@ -244,6 +244,7 @@ func startupdate() {
                 Method:	"update",
                 Fullupdate: fullupdateflag,
                 Bename:   benameflag,
+                Disablebs:   disablebsflag,
                 Updatefile:   updatefileflag,
         }
 

--- a/defines.go
+++ b/defines.go
@@ -58,6 +58,7 @@ var STAGEDIR = "/.updatestage"
 var benameflag string
 var changetrainflag string
 var checkflag bool
+var disablebsflag bool
 var fullupdateflag bool
 var listtrainflag bool
 var stage2flag bool
@@ -67,6 +68,7 @@ var updatekeyflag string
 var websocketflag bool
 func init() {
 	flag.BoolVar(&checkflag, "check", false, "Check system status")
+	flag.BoolVar(&disablebsflag, "disablebootstrap", false, "Disable bootstrap of sysup package on upgrade")
 	flag.BoolVar(&updateflag, "update", false, "Update to latest packages")
 	flag.BoolVar(&listtrainflag, "list-trains", false, "List available trains (if configured)")
 	flag.StringVar(&changetrainflag, "change-train", "", "Change to the specifed new train")
@@ -162,6 +164,7 @@ type UpdateInfo struct {
 type SendReq struct {
 	Method string `json:"method"`
 	Bename string `json:"bename"`
+	Disablebs bool `json:"disablebs"`
 	Fullupdate bool `json:"fullupdate"`
 	Train string `json:"train"`
 	Updatefile string `json:"updatefile"`

--- a/doupdate.go
+++ b/doupdate.go
@@ -61,6 +61,7 @@ func doupdate(message []byte) {
 
 	fullupdateflag = s.Fullupdate
 	benameflag = s.Bename
+	disablebsflag = s.Disablebs
 	updatefileflag = s.Updatefile
 	updatekeyflag = s.Updatekey
 	//log.Println("benameflag: " + benameflag)
@@ -108,7 +109,9 @@ func doupdate(message []byte) {
 
 	// If we have a sysup package we intercept here, do boot-strap and
 	// Then restart the update with the fresh binary on a new port
-	if ( details.SysUp) {
+	//
+	// Skip if the disablebsflag is set
+	if ( details.SysUp && disablebsflag != true) {
 		dosysupbootstrap()
 		dopassthroughupdate()
 		return

--- a/main.go
+++ b/main.go
@@ -92,7 +92,13 @@ func closews() {
 }
 
 func checkuid() {
-	user, _ := user.Current()
+	user, err := user.Current()
+	if ( err != nil ) {
+		fmt.Println(err)
+		fmt.Println("Failed getting user.Current()")
+		os.Exit(1)
+		return
+	}
 	if ( user.Uid != "0" ) {
 		fmt.Println("ERROR: Must be run as root")
 		os.Exit(1)
@@ -101,7 +107,12 @@ func checkuid() {
 
 func main() {
 
-	checkuid()
+	// Can skip if doing stage2 of update
+	// For some reason this fails on some systems when trying to get the current user
+	// possibly due to / not being writable?
+	if ( ! stage2flag ) {
+		checkuid()
+	}
 
 	if len(os.Args) == 1 {
 		flag.Usage()


### PR DESCRIPTION
Add some extra checks to prevent crash if the user.Current() function fails to return a valid user. Also bypass this check on stage2 of an update. Lastly lets add a -disablebootstrap flag so we can bypass the sysup self-update for testing. 

This fixes #5