### PR TITLE
Large update to sysup. Remove the stage2 update process entirely..

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,7 @@ These arguments are add-ons for the "-update" argument and are typically not nee
 - **-fullupdate**
    - Force a "full" update of all packages (including kernel/world).
    - Default Value: This is automatically determined based on whether the base packages (kernel/world) are tagged as newer on the package repository.
-- **-stage2**
-   - Start stage2 of an update (installing non-kernel package updates)
-   - **WARNING** This is a debugging option that is only used internally. This should *not* be run manually by the user.
-   
+
 # TRAINS
 sysup adds the ability to define package "trains". These are basically parallel package repos that might be running at different update intervals or different package configurations (as determined by the package repo maintainer(s)). Trains are considered an optional feature and are not required for single-repository update functionality.
 

--- a/defines.go
+++ b/defines.go
@@ -59,6 +59,7 @@ var STAGEDIR = "/.updatestage"
 // Setup our CLI Flags
 //----------------------------------------------------
 var benameflag string
+var bootloaderflag bool
 var changetrainflag string
 var checkflag bool
 var disablebsflag bool
@@ -76,6 +77,7 @@ func init() {
 	flag.BoolVar(&listtrainflag, "list-trains", false, "List available trains (if configured)")
 	flag.StringVar(&changetrainflag, "change-train", "", "Change to the specifed new train")
 	flag.BoolVar(&fullupdateflag, "fullupdate", false, "Force a full update")
+	flag.BoolVar(&bootloaderflag, "updatebootloader", false, "Perform one-time update of boot-loader")
 	flag.StringVar(&updatefileflag, "updatefile", "", "Use the specified update image instead of fetching from remote")
 	flag.StringVar(&updatekeyflag, "updatekey", "", "Use the specified update pubkey for offline updates (Defaults to none)")
 	flag.StringVar(&benameflag, "bename", "", "Set the name of the new boot-environment for updating. Must not exist yet.")

--- a/defines.go
+++ b/defines.go
@@ -64,7 +64,6 @@ var checkflag bool
 var disablebsflag bool
 var fullupdateflag bool
 var listtrainflag bool
-var stage2flag bool
 var updateflag bool
 var updatefileflag string
 var updatekeyflag string
@@ -77,7 +76,6 @@ func init() {
 	flag.BoolVar(&listtrainflag, "list-trains", false, "List available trains (if configured)")
 	flag.StringVar(&changetrainflag, "change-train", "", "Change to the specifed new train")
 	flag.BoolVar(&fullupdateflag, "fullupdate", false, "Force a full update")
-	flag.BoolVar(&stage2flag, "stage2", false, "Start stage2 of an update (Normally used internally only)")
 	flag.StringVar(&updatefileflag, "updatefile", "", "Use the specified update image instead of fetching from remote")
 	flag.StringVar(&updatekeyflag, "updatekey", "", "Use the specified update pubkey for offline updates (Defaults to none)")
 	flag.StringVar(&benameflag, "bename", "", "Set the name of the new boot-environment for updating. Must not exist yet.")

--- a/doupdate.go
+++ b/doupdate.go
@@ -96,12 +96,6 @@ func doupdate(message []byte) {
 		fullupdateflag = true
 	}
 
-	// If we have been triggerd to run a full update
-	var twostageupdate = false
-	if ( fullupdateflag ) {
-		twostageupdate = true
-	}
-
 	// Start downloading our files if we aren't doing stand-alone upgrade
 	if ( updatefileflag == "" ) {
 		logtofile("Fetching file updates")
@@ -119,14 +113,8 @@ func doupdate(message []byte) {
 		return
 	}
 
-	// Search if a kernel is apart of this update
-	if ( details.KernelUp ) {
-		twostageupdate = true
-	}
-	kernelpkg = details.KernelPkg
-
-	// Start the upgrade with bool passed if doing kernel update
-	startupgrade(twostageupdate)
+	// Start the upgrade
+	startupgrade()
 
 }
 
@@ -358,71 +346,12 @@ IGNORE_OSVERSION: YES` + `
 	logtofile("Done creating new boot-environment")
 }
 
-func updatekernel() {
-	sendinfomsg("Starting stage 1 kernel update")
-	logtofile("Kernel Update Stage 1\n-----------------------")
-
-	// Check if we need to update pkg itself first
-	pkgcmd := exec.Command(PKGBIN, "-c", STAGEDIR, "-C", localpkgconf, "upgrade", "-U", "-y", "-f", "ports-mgmt/pkg")
-	fullout, err := pkgcmd.CombinedOutput()
-	sendinfomsg(string(fullout))
-	logtofile(string(fullout))
-
-	// KPM 11/9/2018
-	// Additionally we may need to do something to ensure we don't load port kmods here on reboot
-	cmd := exec.Command(PKGBIN, "-c", STAGEDIR, "-C", localpkgconf, "upgrade", "-U", "-y", "-f", kernelpkg)
-	logtofile("Starting Kernel upgrade with: " + strings.Join(cmd.Args, " "))
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		log.Fatal(err)
-	}
-	if err := cmd.Start(); err != nil {
-		log.Fatal(err)
-	}
-	buff := bufio.NewScanner(stdout)
-
-	// Iterate over buff and append content to the slice
-	var allText []string
-	for buff.Scan() {
-		line := buff.Text()
-		sendinfomsg(line)
-		logtofile(line)
-		allText = append(allText, line+"\n")
-	}
-        // Pkg returns 0 on sucess
-        if err := cmd.Wait(); err != nil {
-		errbuf, _:= ioutil.ReadAll(stderr)
-		errarr := strings.Split(string(errbuf), "\n")
-		for i, _ := range errarr {
-			sendinfomsg(errarr[i])
-			logtofile(errarr[i])
-		}
-		sendfatalmsg("Failed kernel update!")
-        }
-	sendinfomsg("Finished stage 1 kernel update")
-	logtofile("Finished Kernel Update Stage 1\n-----------------------")
-
-	// Check if we need to do any ZFS automagic
-	sanitize_zfs()
-
-}
-
 func sanitize_zfs() {
 
-        // Check if the new kernel has ZFS module built in, or if we need to update the port
-        if _, err := os.Stat(STAGEDIR + "/boot/kernel/zfs.ko") ; os.IsNotExist(err) {
-		update_zol_port()
-	} else {
-		// If we have a base system ZFS, we need to check if the port needs removing
-		_, err := os.Stat(STAGEDIR + "/boot/modules/zfs.ko")
-		if ( err == nil ) {
-			cleanup_zol_port()
-		}
+	// If we have a base system ZFS, we need to check if the port needs removing
+	_, err := os.Stat(STAGEDIR + "/boot/modules/zfs.ko")
+	if ( err == nil ) {
+		cleanup_zol_port()
 	}
 }
 
@@ -469,25 +398,41 @@ func cleanup_zol_port() {
 	logtofile("Finished ZFS port cleanup stage 1\n-----------------------")
 }
 
-func update_zol_port() {
+func updateincremental(force bool) {
+	sendinfomsg("Starting package update")
+	logtofile("PackageUpdate\n-----------------------")
 
-	sendinfomsg("Updating ZFS port")
-	logtofile("ZFS port update stage 1\n-----------------------")
+	pkgcmd := exec.Command(PKGBIN, "-c", STAGEDIR, "-C", localpkgconf, "upgrade", "-U", "-y", "-f", "ports-mgmt/pkg")
+	fullout, err := pkgcmd.CombinedOutput()
+	sendinfomsg(string(fullout))
+	logtofile(string(fullout))
 
-	// Update the sysutils/zol port
-	cmd := exec.Command(PKGBIN, "-c", STAGEDIR, "-C", localpkgconf, "upgrade", "-U", "-y", "-f", "sysutils/zol")
-	logtofile("Starting ZFS upgrade with: " + strings.Join(cmd.Args, " "))
+	// Setup our main update process
+	cmd := exec.Command(PKGBIN)
+	cmd.Args = append(cmd.Args, "-c")
+	cmd.Args = append(cmd.Args, STAGEDIR)
+	cmd.Args = append(cmd.Args, "-C")
+	cmd.Args = append(cmd.Args, localpkgconf)
+	cmd.Args = append(cmd.Args, "upgrade")
+	cmd.Args = append(cmd.Args, "-U")
+	cmd.Args = append(cmd.Args, "-I")
+	cmd.Args = append(cmd.Args, "-y")
+
+	// Reinstall everything?
+	if ( force ) {
+		cmd.Args = append(cmd.Args, "-f")
+	}
+	logtofile("Starting upgrade with: " + strings.Join(cmd.Args, " "))
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		log.Fatal(err)
-	}
-
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		log.Fatal(err)
+		destroymddev()
+		logtofile("Failed starting pkg upgrade stdout!")
+		sendfatalmsg("Failed starting pkg upgrade stdout!")
 	}
 	if err := cmd.Start(); err != nil {
-		log.Fatal(err)
+		destroymddev()
+		logtofile("Failed starting pkg upgrade!")
+		sendfatalmsg("Failed starting pkg upgrade!")
 	}
 	buff := bufio.NewScanner(stdout)
 
@@ -496,139 +441,20 @@ func update_zol_port() {
 	for buff.Scan() {
 		line := buff.Text()
 		sendinfomsg(line)
-		logtofile(line)
-		allText = append(allText, line+"\n")
-	}
-        // Pkg returns 0 on sucess
-        if err := cmd.Wait(); err != nil {
-		errbuf, _:= ioutil.ReadAll(stderr)
-		errarr := strings.Split(string(errbuf), "\n")
-		for i, _ := range errarr {
-			sendinfomsg(errarr[i])
-			logtofile(errarr[i])
-		}
-		sendfatalmsg("Failed kernel update!")
-        }
-	sendinfomsg("Finished ZFS port update")
-	logtofile("Finished ZFS port update stage 1\n-----------------------")
-}
-
-func updateincremental(chroot bool, force bool, usingws bool) {
-	if ( usingws ) {
-		sendinfomsg("Starting stage 2 package update")
-	} else {
-		log.Println("Starting stage 2 package update")
-	}
-	logtofile("PackageUpdate Stage 2\n-----------------------")
-
-	cmd := exec.Command(PKGBIN)
-	if ( chroot ) {
-		cmd.Args = append(cmd.Args, "-c")
-		cmd.Args = append(cmd.Args, STAGEDIR)
-	}
-	cmd.Args = append(cmd.Args, "-C")
-	cmd.Args = append(cmd.Args, localpkgconf)
-	cmd.Args = append(cmd.Args, "upgrade")
-	cmd.Args = append(cmd.Args, "-U")
-	cmd.Args = append(cmd.Args, "-y")
-	if ( force ) {
-		cmd.Args = append(cmd.Args, "-f")
-	}
-	logtofile("Starting incremental upgrade with: " + strings.Join(cmd.Args, " "))
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		destroymddev()
-		if ( usingws ) {
-			logtofile("Failed starting pkg upgrade stdout!")
-			sendfatalmsg("Failed starting pkg upgrade stdout!")
-		} else {
-			copylogexit(err, "Failed starting pkg upgrade stdout!")
-		}
-	}
-	if err := cmd.Start(); err != nil {
-		destroymddev()
-		if ( usingws) {
-			logtofile("Failed starting pkg upgrade!")
-			sendfatalmsg("Failed starting pkg upgrade!")
-		} else {
-			copylogexit(err, "Failed starting pkg upgrade!")
-		}
-	}
-	buff := bufio.NewScanner(stdout)
-
-	// Iterate over buff and append content to the slice
-	var allText []string
-	for buff.Scan() {
-		line := buff.Text()
-		if ( usingws ) {
-			sendinfomsg(line)
-		} else {
-			log.Println(line)
-		}
 		logtofile("pkg: " + line)
 		allText = append(allText, line+"\n")
 	}
         // Pkg returns 0 on sucess
         if err := cmd.Wait(); err != nil {
 		destroymddev()
-		if ( usingws) {
-			logtofile("Failed pkg upgrade!")
-			sendfatalmsg("Failed pkg upgrade!")
-		} else {
-			copylogexit(err, "Failed pkg upgrade!")
-		}
+		logtofile("Failed pkg upgrade!")
+		sendfatalmsg("Failed pkg upgrade!")
         }
-	if ( usingws ) {
-		sendinfomsg("Finished stage 2 package update")
-	}
-	logtofile("FinishedPackageUpdate Stage 2\n-----------------------")
-
+	sendinfomsg("Finished stage package update")
+	logtofile("FinishedPackageUpdate\n-----------------------")
 }
 
-func updatercscript() {
-        // Intercept the /etc/rc script
-        src := STAGEDIR + "/etc/rc"
-        dest := STAGEDIR + "/etc/rc-updatergo"
-        cpCmd := exec.Command("mv", src, dest)
-	err := cpCmd.Run()
-        if ( err != nil ) {
-                log.Fatal(err)
-        }
-
-	var fuflag string
-	if ( fullupdateflag ) {
-		fuflag="-fullupdate"
-
-	}
-	var cacheflag string
-	if ( cachedirflag != "" ) {
-		cacheflag="-cachedir " + cachedirflag
-
-	}
-
-	var upflag string
-	if ( updatefileflag != "" ) {
-		upflag="-updatefile " + updatefileflag
-	}
-
-	selfbin, _ := os.Executable()
-        ugobin := "/." + toolname
-        cpCmd = exec.Command("install", "-m", "755", selfbin, STAGEDIR + ugobin)
-	err = cpCmd.Run()
-        if ( err != nil ) {
-                log.Fatal(err)
-        }
-
-	// Splat down our intercept
-        fdata := `#!/bin/sh
-PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
-export PATH
-` + ugobin + ` -stage2 ` + fuflag + ` ` + upflag + ` ` + cacheflag
-        ioutil.WriteFile(STAGEDIR + "/etc/rc", []byte(fdata), 0755)
-
-}
-
-func startupgrade(twostage bool) {
+func startupgrade() {
 
 	cleanupbe()
 
@@ -637,12 +463,10 @@ func startupgrade(twostage bool) {
 	// If we are using standalone update need to nullfs mount the pkgs
 	doupdatefilemnt()
 
-	if ( twostage ) {
-		updatekernel()
-		updatercscript()
-	} else {
-		updateincremental(true, fullupdateflag, true)
-	}
+	updateincremental(fullupdateflag)
+
+	// Check if we need to do any ZFS automagic
+	sanitize_zfs()
 
 	// Cleanup nullfs mount
 	doupdatefileumnt(STAGEDIR)
@@ -726,85 +550,6 @@ func copylogexit(perr error, text string) {
 	cmd := exec.Command("reboot")
 	cmd.Run()
 	os.Exit(0)
-}
-
-func preparestage2() {
-	log.Println("Preparing to start update...")
-
-	// Need to ensure ZFS is all mounted and ready
-	cmd := exec.Command("mount", "-u", "rw", "/")
-	err := cmd.Run()
-	if ( err != nil ) {
-		copylogexit(err, "Failed mounting -u rw")
-	}
-
-	// Set the OLD BE as the default in case we crash and burn...
-	dat, err := ioutil.ReadFile("/.updategooldbename")
-	if ( err != nil ) {
-		copylogexit(err, "Failed read .updategooldbename")
-	}
-
-	bename := strings.TrimSpace(string(dat))
-	// Now activate
-	out, err := exec.Command("beadm", "activate", bename).CombinedOutput()
-	if ( err != nil ) {
-		logtofile("Failed beadm activate: " + bename + " " + string(out))
-	}
-
-	// Make sure everything is mounted and ready!
-	cmd = exec.Command("zfs", "mount", "-a")
-	out, err = cmd.CombinedOutput()
-	if ( err != nil ) {
-		logtofile("Failed zfs mount -a: " + string(out))
-	}
-
-	// Need to try and kldload linux64 / linux so some packages can update
-	cmd = exec.Command("kldload", "linux64")
-	err = cmd.Run()
-	if ( err != nil ) {
-		logtofile("WARNING: unable to kldload linux64")
-	}
-	cmd = exec.Command("kldload", "linux")
-	err = cmd.Run()
-	if ( err != nil ) {
-		logtofile("WARNING: unable to kldload linux")
-	}
-
-	// Put back /etc/rc-updatergo so that pkg can update it properly
-	src := "/etc/rc-updatergo"
-        dest := "/etc/rc"
-        cpCmd := exec.Command("mv", src, dest)
-	err = cpCmd.Run()
-        if ( err != nil ) {
-		copylogexit(err, "Failed restoring /etc/rc")
-        }
-}
-
-func startstage2() {
-
-	preparestage2()
-
-	if ( updatefileflag != "" ) {
-		mountofflineupdate()
-	}
-
-	updateincremental(false, fullupdateflag, false)
-
-	destroymddev()
-
-	// SUCCESS! Lets finish and activate the new BE
-	activatebe()
-
-	// Lastly lets update the loader
-	updateloader()
-
-	// Lastly reboot into the new environment
-	cmd := exec.Command("reboot")
-	err := cmd.Run()
-	if ( err != nil ) {
-		log.Fatal(err)
-	}
-
 }
 
 func activatebe() {
@@ -967,7 +712,6 @@ func updateuefi(disk string) bool {
 	logtofile("Unable to locate EFI partition on: " + string(disk))
 	return false
 }
-
 
 func updategpt(disk string) bool {
 	cmd := exec.Command("gpart", "show", disk)

--- a/main.go
+++ b/main.go
@@ -121,13 +121,6 @@ func setlocs() {
 
 func main() {
 
-	// Can skip if doing stage2 of update
-	// For some reason this fails on some systems when trying to get the current user
-	// possibly due to / not being writable?
-	if ( ! stage2flag ) {
-		checkuid()
-	}
-
 	if len(os.Args) == 1 {
 		flag.Usage()
 		os.Exit(1)
@@ -172,11 +165,6 @@ func main() {
 		connectws()
 		startupdate()
 		closews()
-		os.Exit(0)
-	}
-
-	if ( stage2flag ) {
-		startstage2()
 		os.Exit(0)
 	}
 

--- a/main.go
+++ b/main.go
@@ -140,6 +140,13 @@ func main() {
 	// Load the local config file if it exists
 	loadconfig()
 
+	if ( bootloaderflag ) {
+		connectws()
+		updatebootloader()
+		closews()
+		os.Exit(0)
+	}
+
 	if ( listtrainflag ) {
 		connectws()
 		listtrains()

--- a/ws.go
+++ b/ws.go
@@ -38,12 +38,15 @@ func readws(w http.ResponseWriter, r *http.Request) {
 	        switch env.Method {
 	        case "check":
 			checkforupdates()
-		case "update":
-			doupdate(message)
 		case "listtrains":
 			dotrainlist()
 		case "settrain":
 			dosettrain(message)
+		case "update":
+			doupdate(message)
+		case "updatebootloader":
+			updateloader("")
+			sendblmsg("Finished boot-loader process")
 		default:
 			log.Println("Uknown JSON Method:", env.Method)
 		}
@@ -54,6 +57,25 @@ func readws(w http.ResponseWriter, r *http.Request) {
 		//	log.Println("write:", err)
 		//	break
 		//}
+	}
+}
+
+func sendblmsg(info string) {
+	type JSONReply struct {
+		Method string `json:"method"`
+		Info  string `json:"info"`
+	}
+
+	data := &JSONReply{
+		Method:     "updatebootloader",
+		Info:   info,
+	}
+	msg, err := json.Marshal(data)
+	if err != nil {
+		log.Fatal("Failed encoding JSON:", err)
+	}
+	if err := conns.WriteMessage(websocket.TextMessage, msg); err != nil {
+		log.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
After and audit of the ports tree, there are approx 200 ports with install
scripts, and out of those nearly all don't apply on upgrade. For now we will
go back to doing a single pass upgrade / reboot, and disable running post install
scripts for the time being.

If at a later point we find examples of needing these scripts, we can
add a hook to run them via rc.d/init.d service at next boot.