### PR TITLE
Update main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,11 +65,11 @@ func connectws() {
 			connected = true
 			break
 		}
-		time.Sleep(100 * time.Millisecond);
 		// If we fail first connect, lets fire up the internal server
-		if ( attempt == 1 ) {
+		if ( attempt == 0 ) {
 			go startws()
 		}
+		time.Sleep(100 * time.Millisecond);
 	}
 	if (!connected) {
 		log.Fatal("Failed connecting to websocket server", err)


### PR DESCRIPTION
Try to minimize the startup delays when running sysup without a system-wide websocket active.
1. Try to the start the websocket server after the "first" attempt to connect (as the comment states)
2. Move the sleep *after* we startup the websocket server. This should prevent as many iterations waiting for the websocket server to come up.

Minimum time reduction: 0.2 s (from running sleep fewer times), plus the connection will only need to timeout once before starting the websocket server instead of twice.

Another way to minimize downtime would be to put some kind of websocket existance check in before calling websocket.DefaultDialer.Dial(). That would get rid of the connection timeouts and get things going much faster.