### PR TITLE
CHORE: Break out defines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # The default binary
 update-go
 sysup
+tags

--- a/check.go
+++ b/check.go
@@ -4,23 +4,23 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"github.com/gorilla/websocket"
+	"github.com/trueos/sysup/defines"
 	"log"
 	"os/exec"
 	"strings"
-
-	"github.com/gorilla/websocket"
 )
 
-func parseupdatedata(uptext []string) *UpdateInfo {
+func parseupdatedata(uptext []string) *defines.UpdateInfo {
 	var stage string
 	var line string
 
 	// Init the structure
-	details := UpdateInfo{}
-	detailsNew := NewPkg{}
-	detailsUp := UpPkg{}
-	detailsRi := RiPkg{}
-	detailsDel := DelPkg{}
+	details := defines.UpdateInfo{}
+	detailsNew := defines.NewPkg{}
+	detailsUp := defines.UpPkg{}
+	detailsRi := defines.RiPkg{}
+	detailsDel := defines.DelPkg{}
 
 	scanner := bufio.NewScanner(strings.NewReader(strings.Join(uptext, "\n")))
 	for scanner.Scan() {
@@ -144,11 +144,11 @@ func parseupdatedata(uptext []string) *UpdateInfo {
 	return &details
 }
 
-func updatedryrun(sendupdate bool) (*UpdateInfo, bool, error) {
-	details := UpdateInfo{}
+func updatedryrun(sendupdate bool) (*defines.UpdateInfo, bool, error) {
+	details := defines.UpdateInfo{}
 	updetails := &details
 
-	cmd := exec.Command(PKGBIN, "-C", localpkgconf, "upgrade", "-n")
+	cmd := exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "upgrade", "-n")
 	sendinfomsg("Checking system for updates")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -180,11 +180,11 @@ func updatedryrun(sendupdate bool) (*UpdateInfo, bool, error) {
 	return updetails, haveupdates, nil
 }
 
-func sendupdatedetails(haveupdates bool, updetails *UpdateInfo) {
+func sendupdatedetails(haveupdates bool, updetails *defines.UpdateInfo) {
 	type JSONReply struct {
-		Method  string      `json:"method"`
-		Updates bool        `json:"updates"`
-		Details *UpdateInfo `json:"details"`
+		Method  string              `json:"method"`
+		Updates bool                `json:"updates"`
+		Details *defines.UpdateInfo `json:"details"`
 	}
 
 	data := &JSONReply{
@@ -196,7 +196,9 @@ func sendupdatedetails(haveupdates bool, updetails *UpdateInfo) {
 	if err != nil {
 		log.Fatal("Failed encoding JSON:", err)
 	}
-	if err := conns.WriteMessage(websocket.TextMessage, msg); err != nil {
+	if err := defines.Conns.WriteMessage(
+		websocket.TextMessage, msg,
+	); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/client.go
+++ b/client.go
@@ -3,14 +3,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/gorilla/websocket"
+	"github.com/trueos/sysup/defines"
 	"log"
 	"os"
-
-	"github.com/gorilla/websocket"
 )
 
 // Show us our list of trains
-func printtrains(trains []TrainDef, deftrain string) {
+func printtrains(trains []defines.TrainDef, deftrain string) {
 	fmt.Println("Current Train: " + deftrain)
 	fmt.Println("")
 	fmt.Println("The following trains are available:")
@@ -33,15 +33,15 @@ func parsejsonmsg(message []byte) int {
 		return 1
 	}
 	//log.Printf("client-recv: %s", message)
-	var env Envelope
+	var env defines.Envelope
 	if err := json.Unmarshal(message, &env); err != nil {
 		log.Fatal(err)
 	}
 	switch env.Method {
 	case "check":
 		var s struct {
-			Envelope
-			Check
+			defines.Envelope
+			defines.Check
 		}
 		if err := json.Unmarshal(message, &s); err != nil {
 			log.Fatal(err)
@@ -57,8 +57,8 @@ func parsejsonmsg(message []byte) int {
 		}
 	case "info":
 		var s struct {
-			Envelope
-			InfoMsg
+			defines.Envelope
+			defines.InfoMsg
 		}
 		if err := json.Unmarshal(message, &s); err != nil {
 			log.Fatal(err)
@@ -67,8 +67,8 @@ func parsejsonmsg(message []byte) int {
 		fmt.Println(infomsg)
 	case "updatebootloader":
 		var s struct {
-			Envelope
-			InfoMsg
+			defines.Envelope
+			defines.InfoMsg
 		}
 		if err := json.Unmarshal(message, &s); err != nil {
 			log.Fatal(err)
@@ -78,9 +78,9 @@ func parsejsonmsg(message []byte) int {
 		os.Exit(0)
 	case "listtrains":
 		var s struct {
-			Envelope
-			Trains  []TrainDef `json:"trains"`
-			Default string     `json:"default"`
+			defines.Envelope
+			Trains  []defines.TrainDef `json:"trains"`
+			Default string             `json:"default"`
 		}
 		if err := json.Unmarshal(message, &s); err != nil {
 			log.Fatal(err)
@@ -89,7 +89,7 @@ func parsejsonmsg(message []byte) int {
 		os.Exit(0)
 	case "settrain":
 		var s struct {
-			Envelope
+			defines.Envelope
 			Train string `json:"train"`
 		}
 		if err := json.Unmarshal(message, &s); err != nil {
@@ -99,8 +99,8 @@ func parsejsonmsg(message []byte) int {
 		os.Exit(0)
 	case "shutdown":
 		var s struct {
-			Envelope
-			InfoMsg
+			defines.Envelope
+			defines.InfoMsg
 		}
 		if err := json.Unmarshal(message, &s); err != nil {
 			log.Fatal(err)
@@ -110,8 +110,8 @@ func parsejsonmsg(message []byte) int {
 		os.Exit(0)
 	case "fatal":
 		var s struct {
-			Envelope
-			InfoMsg
+			defines.Envelope
+			defines.InfoMsg
 		}
 		if err := json.Unmarshal(message, &s); err != nil {
 			log.Fatal(err)
@@ -156,7 +156,7 @@ func startcheck() {
 }
 
 func updatebootloader() {
-	data := &SendReq{
+	data := &defines.SendReq{
 		Method: "updatebootloader",
 	}
 
@@ -186,7 +186,7 @@ func updatebootloader() {
 }
 
 func listtrains() {
-	data := &SendReq{
+	data := &defines.SendReq{
 		Method: "listtrains",
 	}
 
@@ -216,9 +216,9 @@ func listtrains() {
 }
 
 func settrain() {
-	data := &SendReq{
+	data := &defines.SendReq{
 		Method: "settrain",
-		Train:  changetrainflag,
+		Train:  defines.ChangeTrainFlag,
 	}
 
 	msg, err := json.Marshal(data)
@@ -246,7 +246,7 @@ func settrain() {
 	}
 }
 
-func printupdatedetails(details UpdateInfo) {
+func printupdatedetails(details defines.UpdateInfo) {
 
 	fmt.Println("The following packages will be updated:")
 	fmt.Println("----------------------------------------------------")
@@ -277,13 +277,13 @@ func printupdatedetails(details UpdateInfo) {
 }
 
 func startupdate() {
-	data := &SendReq{
+	data := &defines.SendReq{
 		Method:     "update",
-		Fullupdate: fullupdateflag,
-		Cachedir:   cachedirflag,
-		Bename:     benameflag,
-		Disablebs:  disablebsflag,
-		Updatefile: updatefileflag,
+		Fullupdate: defines.FullUpdateFlag,
+		Cachedir:   defines.CacheDirFlag,
+		Bename:     defines.BeNameFlag,
+		Disablebs:  defines.DisableBsFlag,
+		Updatefile: defines.UpdateFileFlag,
 	}
 
 	msg, err := json.Marshal(data)

--- a/defines/config.go
+++ b/defines/config.go
@@ -1,4 +1,4 @@
-package main
+package defines
 
 import (
 	"encoding/json"
@@ -7,16 +7,16 @@ import (
 	"os"
 )
 
-func loadconfig() bool {
+func LoadConfig() bool {
 	// Try to load the default config file
-	if _, err := os.Stat(configjson); os.IsNotExist(err) {
+	if _, err := os.Stat(ConfigJson); os.IsNotExist(err) {
 		return false
 	}
 
 	// Load the file into memory
-	dat, err := ioutil.ReadFile(configjson)
+	dat, err := ioutil.ReadFile(ConfigJson)
 	if err != nil {
-		log.Fatal("Failed reading configuration file: " + configjson)
+		log.Fatal("Failed reading configuration file: " + ConfigJson)
 	}
 
 	// Set some defaults for values that may not be in the config file
@@ -30,21 +30,21 @@ func loadconfig() bool {
 	}
 
 	// Set our gloabls now
-	bootstrap = s.Bootstrap
-	bootstrapfatal = s.BootstrapFatal
-	trainsurl = s.TrainsURL
+	Bootstrap = s.Bootstrap
+	BootstrapFatal = s.BootstrapFatal
+	TrainsUrl = s.TrainsURL
 
 	// If we have a trains pubkey file specified for verification
 	if s.TrainsPubKey != "" {
-		trainpubkey = s.TrainsPubKey
+		TrainPubKey = s.TrainsPubKey
 	}
 
 	// Don't update these if already set on the CLI
-	if updatekeyflag != "" {
-		updatekeyflag = s.OfflineUpdateKey
+	if UpdateKeyFlag != "" {
+		UpdateKeyFlag = s.OfflineUpdateKey
 	}
-	if cachedirflag != "" {
-		cachedirflag = s.Cachedir
+	if CacheDirFlag != "" {
+		CacheDirFlag = s.CacheDir
 	}
 
 	return true

--- a/defines/defines.go
+++ b/defines/defines.go
@@ -1,14 +1,14 @@
-package main
+package defines
 
 import (
 	"flag"
 	"github.com/gorilla/websocket"
 )
 
-var updater = websocket.Upgrader{} // use default options
+var Updater = websocket.Upgrader{} // use default options
 // Start our client connection to the WS server
 var (
-	conns *websocket.Conn
+	Conns *websocket.Conn
 )
 var pkgflags string
 
@@ -16,32 +16,32 @@ var pkgflags string
 var toolname = "sysup"
 
 // Where to log by default
-var logfile = "/var/log/" + toolname + ".log"
+var LogFile = "/var/log/" + toolname + ".log"
 
 // Configuration file location
-var configjson = "/usr/local/etc/" + toolname + ".json"
+var ConfigJson = "/usr/local/etc/" + toolname + ".json"
 
 // Global trains URL
-var trainsurl string
+var TrainsUrl string
 
 // Set our default bootstrap options
-var bootstrap = false
-var bootstrapfatal = false
+var Bootstrap = false
+var BootstrapFatal = false
 
 // Default pubkey used for trains
-var trainpubkey = "/usr/local/share/" + toolname + "/trains.pub"
+var TrainPubKey = "/usr/local/share/" + toolname + "/trains.pub"
 
 // Package defaults
 //----------------------------------------------------
 var PKGBIN = "pkg-static"
 
-var localsysupdb = "/var/db/" + toolname
-var localpkgdb = localsysupdb + "/pkgdb"
-var localimgmnt = localsysupdb + "/mnt"
-var localpkgconf = localsysupdb + "/pkg.conf"
-var localcachedir = localsysupdb + "/cache"
-var localmddev = ""
-var abioverride = ""
+var SysUpDb = "/var/db/" + toolname
+var PkgDb = SysUpDb + "/pkgdb"
+var ImgMnt = SysUpDb + "/mnt"
+var PkgConf = SysUpDb + "/pkg.conf"
+var CacheDir = SysUpDb + "/cache"
+var MdDev = ""
+var AbiOverride = ""
 
 //----------------------------------------------------
 
@@ -55,99 +55,98 @@ var STAGEDIR = "/.updatestage"
 
 // Setup our CLI Flags
 //----------------------------------------------------
-var addr string
-var benameflag string
-var bootloaderflag bool
-var changetrainflag string
-var checkflag bool
-var disablebsflag bool
-var fullupdateflag bool
-var listtrainflag bool
-var updateflag bool
-var updatefileflag string
-var updatekeyflag string
-var cachedirflag string
-var websocketflag bool
-var websocketAddr string
+var BeNameFlag string
+var BootloaderFlag bool
+var ChangeTrainFlag string
+var CheckFlag bool
+var DisableBsFlag bool
+var FullUpdateFlag bool
+var ListTrainFlag bool
+var UpdateFlag bool
+var UpdateFileFlag string
+var UpdateKeyFlag string
+var CacheDirFlag string
+var WebsocketFlag bool
+var WebsocketAddr string
 
 func init() {
 	flag.BoolVar(
-		&checkflag,
+		&CheckFlag,
 		"check",
 		false,
 		"Check system status",
 	)
 	flag.BoolVar(
-		&disablebsflag,
+		&DisableBsFlag,
 		"disablebootstrap",
 		false,
 		"Disable bootstrap of sysup package on upgrade",
 	)
 	flag.BoolVar(
-		&updateflag,
+		&UpdateFlag,
 		"update",
 		false,
 		"Update to latest packages",
 	)
 
 	flag.BoolVar(
-		&listtrainflag,
+		&ListTrainFlag,
 		"list-trains",
 		false,
 		"List available trains (if configured)",
 	)
 	flag.StringVar(
-		&changetrainflag,
+		&ChangeTrainFlag,
 		"change-train",
 		"",
 		"Change to the specifed new train",
 	)
 	flag.BoolVar(
-		&fullupdateflag,
+		&FullUpdateFlag,
 		"fullupdate",
 		false,
 		"Force a full update",
 	)
 	flag.BoolVar(
-		&bootloaderflag,
+		&BootloaderFlag,
 		"updatebootloader",
 		false,
 		"Perform one-time update of boot-loader",
 	)
 	flag.StringVar(
-		&updatefileflag,
+		&UpdateFileFlag,
 		"updatefile",
 		"",
 		"Use the specified update image instead of fetching from remote",
 	)
 	flag.StringVar(
-		&updatekeyflag,
+		&UpdateKeyFlag,
 		"updatekey",
 		"",
 		"Use the specified update pubkey for offline updates"+
 			" (Defaults to none)",
 	)
 	flag.StringVar(
-		&benameflag,
+		&BeNameFlag,
 		"bename",
 		"",
 		"Set the name of the new boot-environment for updating."+
 			"Must not exist yet.",
 	)
 	flag.StringVar(
-		&cachedirflag,
+		&CacheDirFlag,
 		"cachedir",
 		"",
 		"Set the temp data location where we download files / cache data",
 	)
 	flag.BoolVar(
-		&websocketflag,
+		&WebsocketFlag,
 		"websocket",
 		false,
 		"Start websocket server for direct API access and events",
 	)
 	flag.StringVar(
-		&websocketAddr,
+		&WebsocketAddr,
 		"websocket-addr",
 		"127.0.0.1:8134",
 		"Address to have the websocket server listen on",
@@ -182,7 +181,7 @@ type DelPkg struct {
 type ConfigFile struct {
 	Bootstrap        bool   `json:"bootstrap"`
 	BootstrapFatal   bool   `json:"bootstrapfatal"`
-	Cachedir         string `json:"cachedir"`
+	CacheDir         string `json:"cachedir"`
 	OfflineUpdateKey string `json:"offlineupdatekey"`
 	TrainsURL        string `json:"trainsurl"`
 	TrainsPubKey     string `json:"trainspubkey"`

--- a/ws.go
+++ b/ws.go
@@ -2,22 +2,22 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/gorilla/websocket"
+	"github.com/trueos/sysup/defines"
 	"log"
 	"net/http"
-
-	"github.com/gorilla/websocket"
 )
 
 func readws(w http.ResponseWriter, r *http.Request) {
 	var err error
-	conns, err = updater.Upgrade(w, r, nil)
+	defines.Conns, err = defines.Updater.Upgrade(w, r, nil)
 	if err != nil {
 		log.Print("update:", err)
 		return
 	}
-	defer conns.Close()
+	defer defines.Conns.Close()
 	for {
-		_, message, err := conns.ReadMessage()
+		_, message, err := defines.Conns.ReadMessage()
 		if err != nil {
 			log.Println("read:", err)
 			break
@@ -29,7 +29,7 @@ func readws(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Start decoding the incoming JSON
-		var env Envelope
+		var env defines.Envelope
 		if err := json.Unmarshal(message, &env); err != nil {
 			sendinfomsg("Invalid JSON received")
 			log.Println("Warning: Invalid JSON message received")
@@ -52,7 +52,7 @@ func readws(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// log.Printf("server-recv: %s", message)
-		//err = conns.WriteMessage(mt, message)
+		//err = defines.Conns.WriteMessage(mt, message)
 		//if err != nil {
 		//	log.Println("write:", err)
 		//	break
@@ -74,7 +74,7 @@ func sendblmsg(info string) {
 	if err != nil {
 		log.Fatal("Failed encoding JSON:", err)
 	}
-	if err := conns.WriteMessage(websocket.TextMessage, msg); err != nil {
+	if err := defines.Conns.WriteMessage(websocket.TextMessage, msg); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -93,7 +93,7 @@ func sendinfomsg(info string) {
 	if err != nil {
 		log.Fatal("Failed encoding JSON:", err)
 	}
-	if err := conns.WriteMessage(websocket.TextMessage, msg); err != nil {
+	if err := defines.Conns.WriteMessage(websocket.TextMessage, msg); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -112,7 +112,7 @@ func sendshutdownmsg(info string) {
 	if err != nil {
 		log.Fatal("Failed encoding JSON:", err)
 	}
-	if err := conns.WriteMessage(websocket.TextMessage, msg); err != nil {
+	if err := defines.Conns.WriteMessage(websocket.TextMessage, msg); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -131,7 +131,7 @@ func sendfatalmsg(info string) {
 	if err != nil {
 		log.Fatal("Failed encoding JSON:", err)
 	}
-	if err := conns.WriteMessage(websocket.TextMessage, msg); err != nil {
+	if err := defines.Conns.WriteMessage(websocket.TextMessage, msg); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
This should be its own module. We have no way of knowing where things are defined, as they are not all defined in defines.go. This PR corrects that behavior, along with renaming variables to properly show their public/private status.

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>