### PR TITLE
Now allow specifying port 0, and print that port

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ System Update utility written in GO for TrueOS, FreeNAS, TrueView and related pr
 
 # Command-line Usage and Details
 ## Full lists of options
-* `sysup [-websocket] [-websocket-addr <address>]` : Start a system-wide websocket backend
-* `sysup [-websocket-addr <address>] -check [-updatefile <img file> [-updatekey <keyfile>]]` : Check for updates
-* `sysup [-websocket-addr <address>] [-update | -fullupdate] [-disablebootstrap] [-bename <name>] [-updatefile <img file> [-updatekey <keyfile>]]` : Start updates
-* `sysup [-websocket-addr <address>] -list-trains` : List the available package trains
-* `sysup [-websocket-addr <address>] -change-train <train-name>` : Change to a different package train
+* `sysup [-websocket] [-addr <address>]` : Start a system-wide websocket backend
+* `sysup [-addr <address>] [-port <port>] -check [-updatefile <img file> [-updatekey <keyfile>]]` : Check for updates
+* `sysup [-addr <address>] [-port <port>] [-update | -fullupdate] [-disablebootstrap] [-bename <name>] [-updatefile <img file> [-updatekey <keyfile>]]` : Start updates
+* `sysup [-addr <address>] [-port <port>] -list-trains` : List the available package trains
+* `sysup [-addr <address>] [-port <port>] -change-train <train-name>` : Change to a different package train
 
 ## Typical Examples
 - General Usage:
@@ -61,10 +61,13 @@ These arguments are add-ons for the "-update" argument and are typically not nee
 ###  Daemonizing the updater
 - **-websocket**
    - Startup a websocket service for direct API access and events
-   - This is a primary argument that should not be combined with any other flags except possibly `-addr`
-- **-websocket-addr ADDRESS**
-   - Websocket service address (IP:portnumber). This is a general option for all primary arguments to allow it to talk to a currently-running websocket service
-   - Default value: "127.0.0.1:8134"
+   - This is a primary argument that should not be combined with any other flags except possibly `-addr` and `-port`
+- **-addr ADDRESS**
+   - Websocket service IP address. This is a general option for all primary arguments to allow it to talk to a currently-running websocket service
+   - Default value: "127.0.0.1"
+- **-port PORT**
+  - Websocket service port. This is a general option for all primary arguments to allow it to talk to a currently-running websocket service
+  - Default value: "8134"
    
 # TRAINS
 sysup adds the ability to define package "trains". These are basically parallel package repos that might be running at different update intervals or different package configurations (as determined by the package repo maintainer(s)). Trains are considered an optional feature and are not required for single-repository update functionality.

--- a/defines/defines.go
+++ b/defines/defines.go
@@ -67,6 +67,8 @@ var UpdateFileFlag string
 var UpdateKeyFlag string
 var CacheDirFlag string
 var WebsocketFlag bool
+var WebsocketIP string
+var WebsocketPort int
 var WebsocketAddr string
 
 func init() {
@@ -146,10 +148,16 @@ func init() {
 		"Start websocket server for direct API access and events",
 	)
 	flag.StringVar(
-		&WebsocketAddr,
-		"websocket-addr",
-		"127.0.0.1:8134",
-		"Address to have the websocket server listen on",
+		&WebsocketIP,
+		"addr",
+		"127.0.0.1",
+		"IP Address to have the websocket server listen on",
+	)
+	flag.IntVar(
+		&WebsocketPort,
+		"port",
+		8134,
+		"Port to use when in server mode",
 	)
 	flag.Parse()
 }

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"os/user"
+	"strconv"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -18,8 +19,32 @@ import (
 	"github.com/trueos/sysup/pkg"
 	"github.com/trueos/sysup/trains"
 	"github.com/trueos/sysup/update"
+	"github.com/trueos/sysup/utils"
 	"github.com/trueos/sysup/ws"
 )
+
+// Set up the websocket address
+func setupWs() {
+	if defines.WebsocketPort == 0 {
+		port, err := utils.GetFreePort()
+
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		defines.WebsocketPort = port
+	}
+
+	// We couldn't get a free port
+	if defines.WebsocketPort == 0 {
+		log.Println("ERROR: No free port available to listen on!")
+		os.Exit(100)
+	}
+
+	defines.WebsocketAddr = defines.WebsocketIP + ":" + strconv.Itoa(
+		defines.WebsocketPort,
+	)
+}
 
 // Start the websocket server
 func startws() {
@@ -158,6 +183,7 @@ func main() {
 
 	// Load the local config file if it exists
 	defines.LoadConfig()
+	setupWs()
 
 	if defines.BootloaderFlag {
 		connectws()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 )
 
@@ -29,4 +30,15 @@ func Copyfile(src, dst string) (int64, error) {
 	defer destination.Close()
 	nBytes, err := io.Copy(destination, source)
 	return nBytes, err
+}
+
+func GetFreePort() (int, error) {
+	ln, err := net.Listen("tcp", ":0")
+	defer ln.Close()
+
+	if err != nil {
+		return 0, err
+	}
+
+	return ln.Addr().(*net.TCPAddr).Port, nil
 }


### PR DESCRIPTION
This PR does the following:
- Add a new GetFreePort function to utils.go
- Break apart the varibles for websocket address construction
- Construct defines.WebsocketAddr before any tasks
- Exit on 100 if no free websocket port is available
- Change the flag -websocket-addr to two seperate flags (-addr and -port)

Requested by William

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>