### PR TITLE
NAS-101433 / 11.3 / Add -fetch-only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ sysup allows for the possibility of offline updates via an image file containing
    
 ### Additional Update Options
 These arguments are add-ons for the "-update" argument and are typically not needed for standard use
+- **-fetch-only**
+   - Skip the applying of updates and the sysup bootstrap update. Useful for debugging.
 - **-disablebootstrap**
    - Skip the update of SysUp port. This is used for running locally built SysUp and testing.
 - **-bename NAME**

--- a/defines/defines.go
+++ b/defines/defines.go
@@ -70,6 +70,7 @@ var WebsocketFlag bool
 var WebsocketIP string
 var WebsocketPort int
 var WebsocketAddr string
+var FetchOnlyFlag bool
 
 func init() {
 	flag.BoolVar(
@@ -159,6 +160,13 @@ func init() {
 		8134,
 		"Port to use when in server mode",
 	)
+	flag.BoolVar(
+		&FetchOnlyFlag,
+		"fetch-only",
+		false,
+		"Instruct update to only fetch the updates, not apply them.",
+	)
+
 	flag.Parse()
 }
 
@@ -272,6 +280,7 @@ type SendReq struct {
 	Train      string `json:"train"`
 	Updatefile string `json:"updatefile"`
 	Updatekey  string `json:"updatekey"`
+	Fetchonly  bool   `json:"fetchonly"`
 }
 
 //----------------------------------------------------

--- a/update/update.go
+++ b/update/update.go
@@ -80,15 +80,16 @@ func DoUpdate(message []byte) {
 		startfetch()
 	}
 
-	// Make sure we actually want to perform the update and bootstrap
-	perfomBSUpdate := details.SysUp &&
-		!defines.DisableBsFlag &&
-		!defines.FetchOnlyFlag
+	// User does not want to apply updates
+	if defines.FetchOnlyFlag {
+		return
+	}
+
 	// If we have a sysup package we intercept here, do boot-strap and
 	// Then restart the update with the fresh binary on a new port
 	//
 	// Skip if the disablebsflag is set
-	if perfomBSUpdate {
+	if details.SysUp && !defines.DisableBsFlag {
 		logger.LogToFile("Performing bootstrap")
 		dosysupbootstrap()
 		dopassthroughupdate()
@@ -96,10 +97,8 @@ func DoUpdate(message []byte) {
 		return
 	}
 
-	if !defines.FetchOnlyFlag {
-		// Start the upgrade
-		startupgrade()
-	}
+	// Start the upgrade
+	startupgrade()
 }
 
 // This is called after a sysup boot-strap has taken place

--- a/update/update.go
+++ b/update/update.go
@@ -39,6 +39,7 @@ func DoUpdate(message []byte) {
 	defines.DisableBsFlag = s.Disablebs
 	defines.UpdateFileFlag = s.Updatefile
 	defines.UpdateKeyFlag = s.Updatekey
+	defines.FetchOnlyFlag = s.Fetchonly
 	//log.Println("benameflag: " + benameflag)
 	//log.Println("updatefile: " + updatefileflag)
 
@@ -79,20 +80,26 @@ func DoUpdate(message []byte) {
 		startfetch()
 	}
 
+	// Make sure we actually want to perform the update and bootstrap
+	perfomBSUpdate := details.SysUp &&
+		!defines.DisableBsFlag &&
+		!defines.FetchOnlyFlag
 	// If we have a sysup package we intercept here, do boot-strap and
 	// Then restart the update with the fresh binary on a new port
 	//
 	// Skip if the disablebsflag is set
-	if details.SysUp && defines.DisableBsFlag != true {
+	if perfomBSUpdate {
 		logger.LogToFile("Performing bootstrap")
 		dosysupbootstrap()
 		dopassthroughupdate()
+
 		return
 	}
 
-	// Start the upgrade
-	startupgrade()
-
+	if !defines.FetchOnlyFlag {
+		// Start the upgrade
+		startupgrade()
+	}
 }
 
 // This is called after a sysup boot-strap has taken place


### PR DESCRIPTION
This flag will only fetch the available updates, and not continue with the sysup bootstrap or upgrade.

NAS-101433

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>