### PR TITLE
Improve checking flavors

### DIFF
--- a/update/update.go
+++ b/update/update.go
@@ -463,7 +463,8 @@ func checkFlavorSwitch() {
 		// We are not using the old, we can safely return now
 		return
 	}
-	pkgSlice := make([]string, 12)
+
+	var pkgSlice []string
 	pkgArgs := []string{
 		defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name",
 	}
@@ -512,13 +513,14 @@ func checkFlavorSwitch() {
 
 	for _, pkg := range pkgSlice {
 		args := append(pkgArgs, pkg, "-y")
-		if stderr, err := exec.Command(
+
+		if out, err := exec.Command(
 			args[0], args[1:]...,
 		).CombinedOutput(); err != nil {
 			ws.SendMsg(
-				pkg+" failed to install! Error:\n"+string(stderr), "fatal",
+				pkg+" failed to install! Error:\n"+string(out), "fatal",
 			)
-			log.Fatal(stderr)
+			log.Fatal(out)
 		}
 	}
 }

--- a/update/update.go
+++ b/update/update.go
@@ -75,7 +75,7 @@ func DoUpdate(message []byte) {
 	}
 
 	// Check if we are moving from pre-flavor pkg base to flavors
-	checkflavorswitch()
+	checkFlavorSwitch()
 
 	// Start downloading our files if we aren't doing stand-alone upgrade
 	if defines.UpdateFileFlag == "" {
@@ -446,25 +446,26 @@ func cleanup_zol_port() {
 	)
 }
 
-func checkflavorswitch() {
-
+func checkFlavorSwitch() {
 	// Does the new pkg repo have os-generic-userland flavorized package
 	cmd := exec.Command(
 		defines.PKGBIN, "-C", defines.PkgConf,
 		"rquery", "-U", "%v", "os-generic-userland",
 	)
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		return
 	}
 
 	// We have flavorized package, lets see if we are still using the
 	// old non-flavor version still
 	cmd = exec.Command(defines.PKGBIN, "query", "%v", "userland")
-	err = cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		// We are not using the old, we can safely return now
 		return
+	}
+	pkgSlice := make([]string, 12)
+	pkgArgs := []string{
+		defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name",
 	}
 
 	// Update the old style base packages to their flavor versions
@@ -473,60 +474,53 @@ func checkflavorswitch() {
 	); os.IsNotExist(err) {
 		// Switch to a ZOL base flavor
 		ws.SendMsg("Switching to ZOL base flavor")
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland:os-zol-userland", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland-base:os-zol-userland-base", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland-debug:os-zol-userland-debug", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland-docs:os-zol-userland-docs", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland-lib32:os-zol-userland-lib32", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland-tests:os-zol-userland-tests", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "kernel:os-zol-kernel", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "kernel-debug:os-zol-kernel-debug", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "kernel-debug-symbols:os-zol-kernel-debug-symbols", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "kernel-symbols:os-zol-kernel-symbols", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "buildkernel:os-zol-buildkernel", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "buildworld:os-zol-buildworld", "-y")
-		err = cmd.Run()
+		pkgSlice = append(
+			pkgSlice,
+			"userland:os-zol-userland",
+			"userland-base:os-zol-userland-base",
+			"userland-debug:os-zol-userland-debug",
+			"userland-docs:os-zol-userland-docs",
+			"userland-lib32:os-zol-userland-lib32",
+			"userland-tests:os-zol-userland-tests",
+			"kernel:os-zol-kernel",
+			"kernel-debug:os-zol-kernel-debug",
+			"kernel-debug-symbols:os-zol-kernel-debug-symbols",
+			"kernel-symbols:os-zol-kernel-symbols",
+			"buildkernel:os-zol-buildkernel",
+			"buildworld:os-zol-buildworld",
+		)
+
 	} else {
 		// Switch to a GENERIC base flavor
 		ws.SendMsg("Switching to GENERIC base flavor")
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland:os-generic-userland", "--yes")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland-base:os-generic-userland-base", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland-debug:os-generic-userland-debug", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland-docs:os-generic-userland-docs", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland-lib32:os-generic-userland-lib32", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "userland-tests:os-generic-userland-tests", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "kernel:os-generic-kernel", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "kernel-debug:os-generic-kernel-debug", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "kernel-debug-symbols:os-generic-kernel-debug-symbols", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "kernel-symbols:os-generic-kernel-symbols", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "buildkernel:os-generic-buildkernel", "-y")
-		err = cmd.Run()
-		cmd = exec.Command(defines.PKGBIN, "-C", defines.PkgConf, "set", "--change-name", "buildworld:os-generic-buildworld", "-y")
-		err = cmd.Run()
-
+		pkgSlice = append(
+			pkgSlice,
+			"userland:os-generic-userland",
+			"userland-base:os-generic-userland-base",
+			"userland-debug:os-generic-userland-debug",
+			"userland-docs:os-generic-userland-docs",
+			"userland-lib32:os-generic-userland-lib32",
+			"userland-tests:os-generic-userland-tests",
+			"kernel:os-generic-kernel",
+			"kernel-debug:os-generic-kernel-debug",
+			"kernel-debug-symbols:os-generic-kernel-debug-symbols",
+			"kernel-symbols:os-generic-kernel-symbols",
+			"buildkernel:os-generic-buildkernel",
+			"buildworld:os-generic-buildworld",
+		)
 	}
 
+	for _, pkg := range pkgSlice {
+		args := append(pkgArgs, pkg, "-y")
+		if stderr, err := exec.Command(
+			args[0], args[1:]...,
+		).CombinedOutput(); err != nil {
+			ws.SendMsg(
+				pkg+" failed to install! Error:\n"+string(stderr), "fatal",
+			)
+			log.Fatal(stderr)
+		}
+	}
 }
 
 func checkbaseswitch() {


### PR DESCRIPTION
This PR contains the following:
- Use an easier to read function name
- Combined err and runs to prevent leakage
- Reuse of pkg arguments as a slice
- Run command for each pkg and send a failure containing stderr

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>