### PR TITLE
BE is now a date by default unless version exists

### DIFF
--- a/defines/defines.go
+++ b/defines/defines.go
@@ -3,6 +3,9 @@ package defines
 import (
 	"flag"
 	"github.com/gorilla/websocket"
+	"strconv"
+	"strings"
+	"time"
 )
 
 var Updater = websocket.Upgrader{} // use default options
@@ -48,7 +51,18 @@ var AbiOverride = ""
 // Boot-Environment defaults
 //----------------------------------------------------
 var BEBIN = "beadm"
-var BESTAGE = "updatego-stage"
+var curDate = time.Now()
+
+// We want the int representations of these
+var BESTAGE = strings.Join([]string{
+	strconv.Itoa(curDate.Year()),
+	strconv.Itoa(int(curDate.Month())),
+	strconv.Itoa(curDate.Day()),
+	strconv.Itoa(curDate.Hour()),
+	strconv.Itoa(curDate.Minute()),
+	strconv.Itoa(curDate.Second()),
+}, "-")
+
 var STAGEDIR = "/.updatestage"
 
 //----------------------------------------------------


### PR DESCRIPTION
This PR does the following:
- Remove default name of updatego
- Move BE naming by date to defines.go
- If /etc/version or /etc/base_version exist, we use that as the BE name
- Move failed log file to /var/log/sysup.failed
- Fatally log the error if this occurs

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>