### PR TITLE
For safer package base upgrades, we've split out some critical clibs

### DIFF
--- a/update/update.go
+++ b/update/update.go
@@ -523,7 +523,7 @@ func checkFlavorSwitch() {
 	}
 }
 
-func checkbasebootstrapswitch() {
+func checkBaseBootstrapSwitch() {
 	// Dirty work-around to a bug in pkg today
 	//
 	// Can be removed at a later date when pkg handles more gracefully
@@ -549,15 +549,16 @@ func checkbasebootstrapswitch() {
 
 	// No? Lets prepare to move to this broken out base pkg
 	// Files to remove from pkg sql database
-	var conflictfiles []string
-	conflictfiles = append(conflictfiles, "/libexec/ld-elf.so.1")
-	conflictfiles = append(conflictfiles, "/libexec/ld-elf32.so.1")
-	conflictfiles = append(conflictfiles, "/usr/lib/libc.so")
-	conflictfiles = append(conflictfiles, "/usr/lib/libm.so")
-	conflictfiles = append(conflictfiles, "/usr/lib/libthr.so")
-	conflictfiles = append(conflictfiles, "/lib/libc.so.7")
-	conflictfiles = append(conflictfiles, "/lib/libm.so.5")
-	conflictfiles = append(conflictfiles, "/lib/libthr.so.3")
+	var conflictfiles = []string{
+		"/libexec/ld-elf.so.1",
+		"/libexec/ld-elf32.so.1",
+		"/usr/lib/libc.so",
+		"/usr/lib/libm.so",
+		"/usr/lib/libthr.so",
+		"/lib/libc.so.7",
+		"/lib/libm.so.5",
+		"/lib/libthr.so.3",
+	}
 
 	// Go through and do database surgery now....
 	for i := range conflictfiles {
@@ -707,7 +708,7 @@ func updateincremental(force bool) error {
 	checkbaseswitch()
 
 	// Check if we needto cleanup move to new bootstrap clibs
-	checkbasebootstrapswitch()
+	checkBaseBootstrapSwitch()
 
 	// Make sure the BE has a valid resolv.conf
 	resolv_dest := defines.STAGEDIR + "/etc/resolv.conf"

--- a/update/update.go
+++ b/update/update.go
@@ -832,6 +832,36 @@ func updateincremental(force bool) error {
 		logger.LogToFile(string(fullout))
 	}
 
+	// Regen login.conf db
+	dbcmd := exec.Command(
+		"cap_mkdb", "-l", "-f", defines.STAGEDIR+"/etc/login.conf.db",
+		defines.STAGEDIR+"/etc/login.conf",
+	)
+	// err isn't used
+	fullout, _ = dbcmd.CombinedOutput()
+	ws.SendMsg(string(fullout))
+	logger.LogToFile(string(fullout))
+
+	// Regen pwd db
+	dbcmd = exec.Command(
+		"pwd_mkdb", "-i", "-p", "-d", defines.STAGEDIR+"/etc",
+		defines.STAGEDIR+"/etc/master.passwd",
+	)
+	// err isn't used
+	fullout, _ = dbcmd.CombinedOutput()
+	ws.SendMsg(string(fullout))
+	logger.LogToFile(string(fullout))
+
+	// Regen services db
+	dbcmd = exec.Command(
+		"services_mkdb", "-l", "-q", "-o", defines.STAGEDIR+"/var/db/services.db",
+		defines.STAGEDIR+"/etc/services",
+	)
+	// err isn't used
+	fullout, _ = dbcmd.CombinedOutput()
+	ws.SendMsg(string(fullout))
+	logger.LogToFile(string(fullout))
+
 	// Cleanup orphans
 	pkgcmd = exec.Command(
 		defines.PKGBIN, "-c", defines.STAGEDIR, "-C", defines.PkgConf,


### PR DESCRIPTION
to a userland-base-bootstrap package, such as /libexec/ld-elf.so.1

This exposed a super nasty pkg bug where it detect conflicts in
the files of the old userland-base and the new userland-base-bootstrap
packages, and tries to "helpfully" remove userland-base first, removing
all your configfiles :/

Work around this by sanitizing the pkg db before attemping this upgrade